### PR TITLE
fixed lightning_endermen attack

### DIFF
--- a/Data_Pack/data/custom_ender_dragon/functions/p2/lightning_endermen/main_2.mcfunction
+++ b/Data_Pack/data/custom_ender_dragon/functions/p2/lightning_endermen/main_2.mcfunction
@@ -1,2 +1,2 @@
-execute in the_end at @e[type=minecraft:enderman,distance=..1000] run summon lightning_bolt
+execute in the_end at @e[type=minecraft:enderman] run summon lightning_bolt
 kill @e[type=marker,tag=dragon_endermen]

--- a/Data_Pack/data/custom_ender_dragon/functions/tick.mcfunction
+++ b/Data_Pack/data/custom_ender_dragon/functions/tick.mcfunction
@@ -103,7 +103,7 @@ execute as @e[type=minecraft:area_effect_cloud,tag=lightning_ring] run execute a
 execute at @e[type=minecraft:area_effect_cloud,tag=lightning_ring] positioned over motion_blocking run particle minecraft:dust 0.73 0 1 1.5 ~ ~ ~ 0 0 0 1 1
 
 #lightning endermen
-execute if entity @e[type=marker,tag=dragon_endermen] in the_end as @e[type=minecraft:enderman,distance=..1000] at @s run particle minecraft:soul_fire_flame ~ ~1.5 ~ 0 0 0 0.1 2
+execute if entity @e[type=marker,tag=dragon_endermen] in the_end as @e[type=minecraft:enderman] at @s run particle minecraft:soul_fire_flame ~ ~1.5 ~ 0 0 0 0.1 2
 
 #balls
 execute as @e[type=dragon_fireball,tag=balls] at @s positioned ~ 0 ~ if entity @s[distance=200..] run function custom_ender_dragon:p2/balls/main_2


### PR DESCRIPTION
For custom_ender_dragon, removed distance parameter from code because it was keeping the lightning_endermen attack from executing successfully. Tested.